### PR TITLE
Exclude datasets that are empty after filtering

### DIFF
--- a/R/metadata-extraction_imagery_dataset.R
+++ b/R/metadata-extraction_imagery_dataset.R
@@ -502,6 +502,11 @@ extract_imagery_dataset_metadata = function(metadata,
                                             plot_flightpath = FALSE,
                                             crop_to_contiguous = TRUE,
                                             min_contig_area = 1600) {
+
+  # Print which dataset is being processed
+  dataset_id = metadata$dataset_id[1]
+  message("Processing dataset ", dataset_id, "...")
+
   # Convert from dataframe to SF object
   # TODO ensure that these columns are always the correct/only ones to use
   metadata = sf::st_as_sf(metadata, crs = 4326, coords = c("lon", "lat"))
@@ -522,8 +527,14 @@ extract_imagery_dataset_metadata = function(metadata,
     cropped_metadata_length = nrow(metadata)
     if (cropped_metadata_length < full_metadata_length) {
       n_cropped = full_metadata_length - cropped_metadata_length
-      message("Dropped ", n_cropped, " images that were not within the largest contiguous patch(es) of images retained for dataset ", metadata$dataset_id[1], ".")
+      message("Dropped ", n_cropped, " images that were not within the largest contiguous patch(es) of images retained for dataset ", dataset_id, ".")
     }
+  }
+
+  # If there are < 10 images left in the largest contiguoug polygon, skip
+  if (nrow(metadata) < 10) {
+    message("Less than 10 images in the largest contiguous patch of images retained for dataset ", dataset_id, "; skipping metadata extraction.")
+    return()
   }
 
   # Extract the IDs of the images that were retained

--- a/sandbox/drone-imagery-ingestion/07_extract-exif-metadata-sub-mission.R
+++ b/sandbox/drone-imagery-ingestion/07_extract-exif-metadata-sub-mission.R
@@ -110,6 +110,10 @@ summary_statistics = furrr::future_map(
 # )
 print("Finished computing dataset-level summary statistics")
 
+# Remove the sub-missions that had no valid images (i.e. were assigned the value NULL)
+no_images = sapply(summary_statistics, is.null)
+summary_statistics = summary_statistics[!no_images]
+
 # Extract the elements of the summary statistics
 metadata_perdataset_list = map(summary_statistics, "dataset_metadata")
 polygon_perdataset_list = map(summary_statistics, "mission_polygon")
@@ -124,7 +128,7 @@ polygon_perdataset_list = lapply(polygon_perdataset_list, sf::st_transform, crs 
 metadata_perdataset = bind_rows(metadata_perdataset_list)
 polygon_perdataset = bind_rows(polygon_perdataset_list)
 images_retained = unlist(images_retained_list)
-metadata_perimage = bind_rows(metadata_per_sub_dataset)
+metadata_perimage = bind_rows(metadata_per_dataset)
 
 # Filter the extracted metadata to only include images that were retained in the dataset-level
 # metadata extraction based on intersection with the mission polygon


### PR DESCRIPTION
If the dataset is so small that the simplified geospatial polygon representing the dataset is empty, then no images will be selected which will cause an indexing error. This PR is one potential solution to this problem. What do you think @russelldj ?