### PR TITLE
Update base metashape config for new version of automate-metashape

### DIFF
--- a/sandbox/drone-imagery-ingestion/full-run-configs/base.yml
+++ b/sandbox/drone-imagery-ingestion/full-run-configs/base.yml
@@ -10,6 +10,7 @@ load_project: ""
 # If there are multiple photo folders, set path to the folder that contains all the photo folders
 # If there are no photos to add (e.g., this is an existing project that already has photos in it, set to an empty string ("")
 photo_path: "/example/path/to/photo/folder"
+photo_path_secondary: ""
 separate_calibration_per_path: True
 multispectral: False # Is this a multispectral photo set? If RGB, set to False.
 
@@ -141,7 +142,16 @@ buildDem: # (Metashape: buildDem, (optionally) classifyGroundPoints, exportRaste
 
 buildOrthomosaic: # (Metashape: buildOrthomosaic, exportRaster)
     enabled: True
-    surface: ["DSM-mesh",] # Options: "DTM-ptcloud", "DSM-ptcloud", "DSM-mesh", and/or "Mesh". The surface to build the orthomosaic onto. DTM and DSM refer to elevation models built by Metashape and must be configured to be computed via buildDem, above. Mesh refers to using the mesh model directly rather than first computing a DEM.
+    # TODO This is a very annoying hack because the R yaml parser simplifies one-length lists into a
+    # single element. To get around this, we duplicate the element, running the same operation
+    # twice. Fortunately, this operation is relatively quick in the scheme of things.
+    # See discussions below.
+    # https://stackoverflow.com/questions/23475743/yaml-in-r-passing-in-a-one-element-list
+    # https://github.com/vubiostat/r-yaml/issues/69
+    # Options: "DTM-ptcloud", "DSM-ptcloud", "DSM-mesh", and/or "Mesh". The surface to build the orthomosaic onto. DTM and DSM refer to elevation models built by Metashape and must be configured to be computed via buildDem, above. Mesh refers to using the mesh model directly rather than first computing a DEM.
+    surface:
+        - DSM-mesh
+        - DSM-mesh
     blending: Metashape.MosaicBlending # Photo blending mode. Options include AverageBlending, MosaicBlending, MinBlending, MaxBlending, DisabledBlending
     fill_holes: True # Fill holes in orthomosaic where no photo data exist by interpolating?
     refine_seamlines: True # Use smart algorithm to identify photo seamlines where they will least distort.

--- a/sandbox/drone-imagery-ingestion/full-run-configs/base.yml
+++ b/sandbox/drone-imagery-ingestion/full-run-configs/base.yml
@@ -141,7 +141,7 @@ buildDem: # (Metashape: buildDem, (optionally) classifyGroundPoints, exportRaste
 
 buildOrthomosaic: # (Metashape: buildOrthomosaic, exportRaster)
     enabled: True
-    surface: ["DSM-mesh"] # Options: "DTM-ptcloud", "DSM-ptcloud", "DSM-mesh", and/or "Mesh". The surface to build the orthomosaic onto. DTM and DSM refer to elevation models built by Metashape and must be configured to be computed via buildDem, above. Mesh refers to using the mesh model directly rather than first computing a DEM.
+    surface: ["DSM-mesh",] # Options: "DTM-ptcloud", "DSM-ptcloud", "DSM-mesh", and/or "Mesh". The surface to build the orthomosaic onto. DTM and DSM refer to elevation models built by Metashape and must be configured to be computed via buildDem, above. Mesh refers to using the mesh model directly rather than first computing a DEM.
     blending: Metashape.MosaicBlending # Photo blending mode. Options include AverageBlending, MosaicBlending, MinBlending, MaxBlending, DisabledBlending
     fill_holes: True # Fill holes in orthomosaic where no photo data exist by interpolating?
     refine_seamlines: True # Use smart algorithm to identify photo seamlines where they will least distort.

--- a/sandbox/drone-imagery-ingestion/full-run-configs/base.yml
+++ b/sandbox/drone-imagery-ingestion/full-run-configs/base.yml
@@ -42,10 +42,16 @@ gpu_multiplier: 2
 ## Refer to Metashape documentation for full parameter definitions: https://www.agisoft.com/pdf/metashape_python_api_1_5_0.pdf
 ## Parameter names here generally follow the parameter names of the Metashape functions.
 
-### Whether to use image EXIF RTK flags to make image geospatial accuracy more precise. If enabled but photos don't have RTK data, will treat them as regular photos and use the nofix accuracy.
-use_rtk: False
-fix_accuracy: 3 # Accuracy to set for photos that have a RTK fix, in units of the CRS
-nofix_accuracy: 25 # Accuracy to set for photos that have no fix, in units of the CRS
+# Should the photos at the path(s) listed above be added to the project? Can disable if, for
+# example, you only want to add GCPs (or do additional processing) to an existing project.
+addPhotos: # (Metashape: addPhotos)
+  enabled: True # This applies to the main photos specified in photo_path above. Secondary photos are always added and aligned if a path (or paths) is provided.
+  separate_calibration_per_path: False # If True, each photo path (i.e. each element in the list supplied to 'photo_path' above) will be calibrated independently. Regardless whether True or False, separate camera *models* are calibrated separately; if True, identical camera *models* are calibrated separately if they are provided as separate paths. This addresses the case where two different instances of the same camera model are used in the same project. Note that when True, the logic for assigning separate calibration to each path assumes that the same camera is used for all photos in the path.
+  multispectral: False # Is this a multispectral photo set? If RGB, set to False.
+  use_rtk: False # Whether to use image EXIF RTK flags to make image geospatial accuracy more precise. If enabled but photos don't have RTK data, will treat them as regular photos and use the nofix accuracy.
+  fix_accuracy: 3 # Accuracy to set for photos that have a RTK fix, in units of the CRS
+  nofix_accuracy: 25 # Accuracy to set for photos that have no fix, in units of the CRS
+
 
 # To use GCPs, a 'gcps' folder must exist in the top level photos folder. The contents of the 'gcps' folder are created by the prep_gcps.R script. See readme: https://github.com/ucdavis/metashape
 addGCPs:

--- a/sandbox/drone-imagery-ingestion/full-run-configs/base.yml
+++ b/sandbox/drone-imagery-ingestion/full-run-configs/base.yml
@@ -90,7 +90,13 @@ filterPointsUSGS:
 optimizeCameras: # (Metashape: optimizeCameras)
     enabled: True
     adaptive_fitting: True # Should the camera lens model be fit at the same time as optimizing photos?
-    export: True # Export the camera locations, now updated from the initial alignment
+
+# Should an xml file specifying estimated camera locations (transform matrices) be exported? If
+# enabled, it is exported once after all alignment-related steps (e.g., align, fliter points,
+# optimize cameras) -- even if these steps are disabled -- and then again after aligning the
+# secondary set of locations (if performed), overwriting the first file
+exportCameras: # (Metashape: exportCameras)
+    enabled: True
 
 buildDepthMaps: # (Metashape: buildDepthMaps)
     enabled: True

--- a/sandbox/drone-imagery-ingestion/full-run-configs/base.yml
+++ b/sandbox/drone-imagery-ingestion/full-run-configs/base.yml
@@ -142,16 +142,16 @@ buildDem: # (Metashape: buildDem, (optionally) classifyGroundPoints, exportRaste
 
 buildOrthomosaic: # (Metashape: buildOrthomosaic, exportRaster)
     enabled: True
-    # TODO This is a very annoying hack because the R yaml parser simplifies one-length lists into a
-    # single element. To get around this, we duplicate the element, running the same operation
-    # twice. Fortunately, this operation is relatively quick in the scheme of things.
-    # See discussions below.
+    # Note that there is a bug in the R yaml parser that turns one-length lists into a single
+    # element. This means there needs to be at least two options here. Alternatively, you can
+    # duplicate a single one, which is fine since generating the ortho is fairly quick. See
+    # descriptions of the issue below.
     # https://stackoverflow.com/questions/23475743/yaml-in-r-passing-in-a-one-element-list
     # https://github.com/vubiostat/r-yaml/issues/69
     # Options: "DTM-ptcloud", "DSM-ptcloud", "DSM-mesh", and/or "Mesh". The surface to build the orthomosaic onto. DTM and DSM refer to elevation models built by Metashape and must be configured to be computed via buildDem, above. Mesh refers to using the mesh model directly rather than first computing a DEM.
     surface:
         - DSM-mesh
-        - DSM-mesh
+        - DSM-ptcloud
     blending: Metashape.MosaicBlending # Photo blending mode. Options include AverageBlending, MosaicBlending, MinBlending, MaxBlending, DisabledBlending
     fill_holes: True # Fill holes in orthomosaic where no photo data exist by interpolating?
     refine_seamlines: True # Use smart algorithm to identify photo seamlines where they will least distort.


### PR DESCRIPTION
The config needed to be updated to be consistent with the most recent version of `automate-metashape`
- Add an `addPhotos` collection
- Add an `exportCameras` collection
- Add `secondary_photo_path`
- Duplicate the ortho surface so it is not coerced into a single-length list. See issue [here](https://github.com/vubiostat/r-yaml/issues/69).

I have tested this config piecemeal, I'm currently running a job start-to-finish to validate it.