### PR TITLE
Add jinjar to imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ Imports:
     yaml,
     lidR,
     xml2,
-    suntools
+    suntools,
+    jinjar
 URL: https://github.com/open-forest-observatory/ofo
 BugReports: https://github.com/open-forest-observatory/ofo/issues


### PR DESCRIPTION
It looks like `jinjar` is required for some of the website templating code but it's not included in the imports.