### PR TITLE
Improve photogrammetry post-processing

### DIFF
--- a/sandbox/drone-imagery-ingestion/20_postprocess-photogrammetry-products.R
+++ b/sandbox/drone-imagery-ingestion/20_postprocess-photogrammetry-products.R
@@ -13,13 +13,20 @@ METASHAPE_OUTPUTS_PATH = "/ofo-share/drone-imagery-processed/01/metashape-output
 PHOTOGRAMMETRY_PUBLISH_PATH = "/ofo-share/drone-imagery-processed/01/photogrammetry-publish"
 MISSION_FOOTPRINTS_PATH = "/ofo-share/drone-imagery-organization/3c_metadata-extracted/all-mission-polygons-w-metadata.gpkg"
 
+# Visualize products as they are being created
 VISUALIZE = FALSE
+# Skip output files already present on disk. Does not check for validity.
 SKIP_EXISTING = FALSE
 
+# Move data to the publish_path and run cropping and conversion to cloud optimized format if
+# appropriate for that file type
 RUN_CONVERSION = TRUE
+# Create the canopy height model
 RUN_CHM = TRUE
+# Create the thumbnail image preview from raster data
 RUN_THUMBNAIL = TRUE
 
+# Upper/lower bounds for which dataset IDs to process
 CONVERSION_LOWER_BOUND_DATASET = 1
 CONVERSION_UPPER_BOUND_DATASET = 10e+6
 

--- a/sandbox/drone-imagery-ingestion/20_postprocess-photogrammetry-products.R
+++ b/sandbox/drone-imagery-ingestion/20_postprocess-photogrammetry-products.R
@@ -62,7 +62,10 @@ list_photogrammetry_outputs = function(input_folder, lower_bounds_dataset = 0, u
 
   # Convert dataset_ids to indices and determine which ones are within the specified range of IDs
   int_dataset_ids = strtoi(dataset_ids, base = 10)
-  elements_in_bounds = (int_dataset_ids >= lower_bounds_dataset) & (int_dataset_ids <= upper_bound_dataset)
+  elements_in_bounds = which(
+    (int_dataset_ids >= lower_bounds_dataset) &
+      (int_dataset_ids <= upper_bound_dataset)
+  )
   # Only retain the rows for datasets within the specified IDs
   processed_files = processed_files[elements_in_bounds, ]
 


### PR DESCRIPTION
This adds a couple of small changes.

- The ability to set bounds on which datasets should be converted
- The ability to control what fraction of the memory `terra` can access. The default 60% cap seems to lead to silent errors if gdal knows more memory will be required.
- Encourage the raster writer to use the bigtiff format by changing from the default flag of `IF_NEEDED` to `IF_SAFER`, see [here](https://gdal.org/en/stable/drivers/raster/gtiff.html). It seems that when compression is applied, bigtiff is not used even if the file is bigger than 4GB, at least when it is close to the limit. 