### PR TITLE
Add patch for visualization of single ASL value

### DIFF
--- a/R/web-catalog-creation_drone-imagery-curation.R
+++ b/R/web-catalog-creation_drone-imagery-curation.R
@@ -175,10 +175,16 @@ make_mission_details_map = function(mission_summary_foc,
 
   # Define color palettes
   pal_hourselapsed = colorNumeric("viridis", domain = mission_points_foc$hours_elapsed)
-  pal_asl = colorNumeric("viridis", domain = mission_points_foc$altitude_asl_drone)
   pal_pitch = colorNumeric("viridis", domain = mission_points_foc$camera_pitch)
   pal_rtk = colorFactor("viridis", domain = mission_points_foc$rtk)
   pal_sub_mission = colorFactor("viridis", domain = mission_points_foc$sub_mission)
+  # All the values of the altitude may be the same. In this case, use a categorical color map to
+  # ensure the value is still shown on the legend.
+  if (min(mission_points_foc$altitude_asl_drone) == max(mission_points_foc$altitude_asl_drone)) {
+    pal_asl = colorFactor("viridis", domain = mission_points_foc$altitude_asl_drone)
+  } else {
+    pal_asl = colorNumeric("viridis", domain = mission_points_foc$altitude_asl_drone)
+  }
 
   m = leaflet() |>
     addPolygons(data = mission_summary_foc, group = "bounds",


### PR DESCRIPTION
In the current version, the legend for ASL will have no information if there is only one distinct value. This is common for small datasets without terrain following since the ASL values are rounded to integers. In those cases, the categorical color mapping is applied so a label is still shown, just in a slightly different style.