### PR TITLE
Support missing `SerialNumber` metadata

### DIFF
--- a/sandbox/drone-imagery-ingestion/01_read_folder_exif_to_csv.R
+++ b/sandbox/drone-imagery-ingestion/01_read_folder_exif_to_csv.R
@@ -35,19 +35,28 @@ get_image_data = function(dataset_folder) {
   date_null = is.null(exif$DateTimeOriginal)
   model_null = is.null(exif$Model)
   serialnumber_null = is.null(exif$SerialNumber)
-  if(date_null || model_null || serialnumber_null) {
+
+  if (date_null || model_null) {
     warning("Null values (likely complete image corruption) found in ", base_folder, ". Skipping.")
     return(NULL)
   }
 
-  image_data_onefolder = data.frame(folder_in = base_folder,
-                           image_path = image_filepaths,
-                           date = exif$DateTimeOriginal,
-                           model = exif$Model,
-                           serialnumber = exif$SerialNumber)
+  # If the serial number is missing (as in the case of the Matrice 100) replace it with the model
+  if (serialnumber_null) {
+    serial_number = exif$Model
+  } else {
+    serial_number = exif$SerialNumber
+  }
+
+  image_data_onefolder = data.frame(
+    folder_in = base_folder,
+    image_path = image_filepaths,
+    date = exif$DateTimeOriginal,
+    model = exif$Model,
+    serialnumber = serial_number
+  )
 
   return(image_data_onefolder)
-
 }
 
 


### PR DESCRIPTION
Add an option to use the model name in place of the serial number if it's not present. This has shown up as a problem for the Matrice 100 platform.