### PR TITLE
Fix some broken metadata extraction (file size, sub-mission ID list, comment typo)

### DIFF
--- a/R/metadata-extraction_imagery_dataset.R
+++ b/R/metadata-extraction_imagery_dataset.R
@@ -352,7 +352,7 @@ extract_image_count = function(metadata) {
 #'
 #' @export
 extract_file_size_summary = function(metadata) {
-  file_size = sum(metadata$FileSize) / 1000000000
+  file_size = sum(metadata$file_size_gb)
 
   file_size = round(file_size, 2)
 

--- a/R/metadata-extraction_imagery_perimage.R
+++ b/R/metadata-extraction_imagery_perimage.R
@@ -140,6 +140,11 @@ extract_file_format = function(exif) {
   return(file_format)
 }
 
+extract_file_size = function(exif) {
+  file_size_gb = exif$FileSize / 1000000000
+  return(file_size_gb)
+}
+
 #### pitch_roll_yaw: camera_pitch (Units: deg, degrees up from nadir), camera_roll (Units: deg, degrees clockwise from up), camera_yaw (Units: deg, degrees right from true north) ####
 
 #' Returns camera pitch, camera roll, and camera yaw. Units: degrees.
@@ -381,6 +386,7 @@ extract_imagery_perimage_metadata = function(exif, platform_name, plot_flightpat
   altitude_asl_drone = extract_altitude_asl(exif)
   image_shape = extract_image_shape(exif)
   file_format = extract_file_format(exif)
+  file_size_gb = extract_file_size(exif)
 
   metadata = data.frame(
     image_id = image_id,
@@ -397,7 +403,8 @@ extract_imagery_perimage_metadata = function(exif, platform_name, plot_flightpat
     received_image_path = received_image_path,
     altitude_asl_drone = altitude_asl_drone,
     image_shape,
-    file_format = file_format
+    file_format = file_format,
+    file_size_gb = file_size_gb
   )
 
   # Remove any rows with missing GPS data

--- a/R/web-catalog-creation_drone-imagery-curation.R
+++ b/R/web-catalog-creation_drone-imagery-curation.R
@@ -453,7 +453,7 @@ make_mission_details_datatable = function(mission_summary_foc,
     # Select just what's needed for a datatable
     dplyr::select(
       "Mission ID" = dataset_id,
-      "Sub-mission IDs" = sub_mission_id,
+      "Sub-mission IDs" = sub_mission_ids,
       "Date" = earliest_date_derived,
       "Altitude (nominal) (m)" = altitude_agl_nominal,
       "Altitude AGL mean (actual) (m)" = altitude_agl_mean_derived,

--- a/sandbox/drone-imagery-ingestion/03_compile-baserow-metadata.R
+++ b/sandbox/drone-imagery-ingestion/03_compile-baserow-metadata.R
@@ -50,8 +50,7 @@ baserow_datasets = baserow_datasets |>
 baserow_projects = baserow_projects |>
   select(project_id, contributor_names, contact_info, license, objectives)
 baserow_datasets = baserow_datasets |>
-  left_join(baserow_projects, by = c("project_id" = "project_id")) |>
-  select(-project_id)
+  left_join(baserow_projects, by = c("project_id" = "project_id"))
 
 # Apply any dataset-level contributor overrides
 baserow_datasets = baserow_datasets |>

--- a/sandbox/drone-imagery-ingestion/10_merge-exif-and-baserow.R
+++ b/sandbox/drone-imagery-ingestion/10_merge-exif-and-baserow.R
@@ -34,7 +34,10 @@ exif_metadata_sub_mission = read_csv(exif_metadata_sub_mission_filepath)
 # In the context of a mission, the sub_mission_id has different meanings in baserow and the exif.
 # In baserow, it means the list of sub-missions included in the mission that a given image is part of.
 # In the exif it is just the sub-mission that a given image is a part of.
-baserow_mission = subset(baserow_mission, select = -c(dataset_id, sub_mission_id))
+baserow_mission = baserow_mission |>
+  rename(sub_mission_ids = sub_mission_id) |>
+  select(-dataset_id)
+
 baserow_sub_mission = subset(baserow_sub_mission, select = -dataset_id)
 
 # Generate image-level metadata

--- a/sandbox/drone-imagery-ingestion/10_merge-exif-and-baserow.R
+++ b/sandbox/drone-imagery-ingestion/10_merge-exif-and-baserow.R
@@ -40,7 +40,7 @@ baserow_mission = baserow_mission |>
 
 baserow_sub_mission = subset(baserow_sub_mission, select = -dataset_id)
 
-# Generate image-level metadata
+# Generate mission and sub-mission-level metadata
 metadata_mission = right_join(
   baserow_mission,
   exif_metadata_mission,


### PR DESCRIPTION
There were a few minor lingering issues of some metadata extraction that was apparently broken (or removed) by the switch from `dataset_id` to `mission_id`. This fixes/restores them.

- Raw imagery file size extraction
- Keep the list of `sub_mission_id`s that comprise a mission, but rename it to distinguish it from sub_mission_id as used in the raw imagery points metadata, which indicates which sub_mission the image is from.
- Retain project ID in mission-level metadata
- A comment typo 